### PR TITLE
FEATURE: Delete videos when posts are deleted

### DIFF
--- a/app/controllers/brightcove/display_controller.rb
+++ b/app/controllers/brightcove/display_controller.rb
@@ -6,6 +6,9 @@ module Brightcove
 
     def show
       @video_id = params.require(:video_id)
+      video = Brightcove::Video.find_by(video_id: @video_id, tombstoned_at: nil)
+      raise Discourse::NotFound if video.nil?
+
       render layout: false
     end
   end

--- a/app/jobs/scheduled/clean_up_brightcove_videos.rb
+++ b/app/jobs/scheduled/clean_up_brightcove_videos.rb
@@ -1,24 +1,47 @@
 # frozen_string_literal: true
 module Jobs
-  class CleanUpBrightcoveVideos < Jobs::Scheduled
+  class CleanUpBrightcoveVideos < ::Jobs::Scheduled
     every 1.hour
+
+    TOMBSTONE_DURATION = 7.days
+
+    POSTS_WITH_VIDEO_SQL = <<~SQL
+      SELECT 1 FROM post_custom_fields pcf
+        JOIN posts p on pcf.post_id = p.id
+        JOIN topics t on p.topic_id = t.id
+        WHERE pcf.name = '#{Brightcove::POST_CUSTOM_FIELD_NAME}'
+        AND pcf.value LIKE CONCAT(brightcove_videos.video_id, ':%')
+        AND (t.deleted_at IS NULL OR t.deleted_at > :deleted_threshold)
+        AND (p.deleted_at IS NULL OR p.deleted_at > :deleted_threshold)
+    SQL
 
     def execute(args)
       return unless SiteSetting.brightcove_enabled
 
+      # Tombstone any orphaned videos
       orphaned_videos = Brightcove::Video.\
         where("brightcove_videos.created_at < ?", 7.days.ago).
-        where(<<~SQL
+        where(tombstoned_at: nil).
+        where(<<~SQL,
           brightcove_videos.state <> 'ready'
-          OR NOT EXISTS
-            (SELECT 1 FROM post_custom_fields pcf
-              WHERE pcf.name = '#{Brightcove::POST_CUSTOM_FIELD_NAME}'
-              AND pcf.value LIKE CONCAT(brightcove_videos.video_id, ':%')
-            )
+          OR NOT EXISTS (#{POSTS_WITH_VIDEO_SQL})
         SQL
-        )
+        deleted_threshold: 1.day.ago)
+      orphaned_videos.update_all(tombstoned_at: Time.zone.now)
 
-      orphaned_videos.find_each do |video|
+      # Untombstone any videos which now have associated posts
+      restorable_videos = Brightcove::Video.\
+        where("tombstoned_at IS NOT NULL").
+        where(<<~SQL,
+          brightcove_videos.state = 'ready'
+          AND EXISTS (#{POSTS_WITH_VIDEO_SQL})
+        SQL
+        deleted_threshold: 1.day.ago)
+      restorable_videos.update_all(tombstoned_at: nil)
+
+      # Delete tombstoned videos from brightcove after duration
+      tombstoned = Brightcove::Video.where("tombstoned_at < ?", TOMBSTONE_DURATION.ago)
+      tombstoned.find_each do |video|
         api = Brightcove::API.new(video.video_id)
         begin
           api.delete

--- a/app/models/brightcove/video.rb
+++ b/app/models/brightcove/video.rb
@@ -30,3 +30,22 @@ module Brightcove
 
   end
 end
+
+# == Schema Information
+#
+# Table name: brightcove_videos
+#
+#  id                :bigint           not null, primary key
+#  video_id          :string           not null
+#  state             :string           not null
+#  secret_access_key :string
+#  api_request_url   :string
+#  callback_key      :string
+#  created_at        :datetime
+#  user_id           :integer
+#  tombstoned_at     :datetime
+#
+# Indexes
+#
+#  index_brightcove_videos_on_video_id  (video_id) UNIQUE
+#

--- a/db/migrate/20210705131100_add_tombstoned_at_to_brightcove_videos.rb
+++ b/db/migrate/20210705131100_add_tombstoned_at_to_brightcove_videos.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+class AddTombstonedAtToBrightcoveVideos < ActiveRecord::Migration[6.1]
+  def change
+    add_column :brightcove_videos, :tombstoned_at, :timestamp
+  end
+end

--- a/plugin.rb
+++ b/plugin.rb
@@ -36,7 +36,8 @@ after_initialize do
   on(:post_process_cooked) do |doc, post|
     video_ids = []
     doc.css("div/@data-video-id").each do |media|
-      if video = Brightcove::Video.find_by_video_id(media.value)
+      if video = Brightcove::Video.find_by(video_id: media.value)
+        video.update(tombstoned_at: nil) if video.tombstoned_at
         video_ids << video.post_custom_field_value
       end
     end

--- a/spec/jobs/clean_up_brightcove_videos_spec.rb
+++ b/spec/jobs/clean_up_brightcove_videos_spec.rb
@@ -11,11 +11,15 @@ describe Jobs::CleanUpBrightcoveVideos do
   }
 
   let!(:post) { Fabricate(:post) }
+  let!(:deleted_post) { Fabricate(:post, deleted_at: 2.days.ago) }
+  let!(:deleted_topic_post) { Fabricate(:post).tap { |p| p.topic.update(deleted_at: 2.days.ago) } }
   let!(:pending_video) { Brightcove::Video.create!(video_id: "0001", state: "pending", created_at: 2.weeks.ago) }
   let!(:errored_video) { Brightcove::Video.create!(video_id: "0002", state: "errored", created_at: 2.weeks.ago) }
   let!(:used_video) { Brightcove::Video.create!(video_id: "0003", state: "ready", created_at: 2.weeks.ago) }
   let!(:unused_video) { Brightcove::Video.create!(video_id: "0004", state: "ready", created_at: 2.weeks.ago) }
   let!(:new_video) { Brightcove::Video.create!(video_id: "0005", state: "ready", created_at: 1.minute.ago) }
+  let!(:deleted_post_video) { Brightcove::Video.create!(video_id: "0006", state: "ready", created_at: 1.week.ago) }
+  let!(:deleted_topic_video) { Brightcove::Video.create!(video_id: "0007", state: "ready", created_at: 1.week.ago) }
 
   before do
     SiteSetting.brightcove_enabled = true
@@ -26,22 +30,29 @@ describe Jobs::CleanUpBrightcoveVideos do
         value: vid.post_custom_field_value
       }
     })
+    PostCustomField.create!(post: deleted_post, name: Brightcove::POST_CUSTOM_FIELD_NAME, value: deleted_post_video.post_custom_field_value)
+    PostCustomField.create!(post: deleted_topic_post, name: Brightcove::POST_CUSTOM_FIELD_NAME, value: deleted_topic_video.post_custom_field_value)
   end
 
-  it "cleans up the correct videos" do
-    delete_stub = stub_request(:delete, /cms.api.brightcove.com\/v1\/accounts\/1234\/videos\/[0-9]+/).to_return(status: 204)
-
-    expect(Brightcove::Video.all.pluck(:video_id)). to contain_exactly("0001", "0002", "0003", "0004", "0005")
+  it "tombstones, then deletes the correct videos" do
     described_class.new.execute(nil)
-    expect(delete_stub).to have_been_requested.times(3)
-    expect(Brightcove::Video.all.pluck(:video_id)). to contain_exactly("0003", "0005")
+    expect(Brightcove::Video.where.not(tombstoned_at: nil).pluck(:video_id)).to contain_exactly("0001", "0002", "0004", "0006", "0007")
+    expect(Brightcove::Video.where(tombstoned_at: nil).pluck(:video_id)).to contain_exactly("0003", "0005")
+
+    freeze_time 2.weeks.from_now do
+      delete_stub = stub_request(:delete, /cms.api.brightcove.com\/v1\/accounts\/1234\/videos\/[0-9]+/).to_return(status: 204)
+      described_class.new.execute(nil)
+      expect(delete_stub).to have_been_requested.times(5)
+      expect(Brightcove::Video.all.pluck(:video_id)).to contain_exactly("0003", "0005")
+    end
   end
 
   it "stops and reschedules when rate limited" do
     delete_stub = stub_request(:delete, /cms.api.brightcove.com\/v1\/accounts\/1234\/videos\/[0-9]+/).
       to_return(status: 204).then.to_return(status: 429)
 
-    expect(Brightcove::Video.all.pluck(:video_id)). to contain_exactly("0001", "0002", "0003", "0004", "0005")
+    pending_video.update(tombstoned_at: 2.weeks.ago)
+    errored_video.update(tombstoned_at: 2.weeks.ago)
 
     expect { described_class.new.execute(nil) }.
       to change { Brightcove::Video.count }.by(-1) &

--- a/spec/requests/display_controller_spec.rb
+++ b/spec/requests/display_controller_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require "rails_helper"
+
+RSpec.describe Brightcove::DisplayController do
+  before do
+    SiteSetting.brightcove_enabled = true
+    SiteSetting.brightcove_account_id = "987654321"
+    SiteSetting.brightcove_client_id = 123
+    SiteSetting.brightcove_client_secret = "abc"
+  end
+
+  let!(:video) { Brightcove::Video.create!(video_id: "12", secret_access_key: "abcd", state: "ready", api_request_url: "https://hello.world/video.mp4", callback_key: SecureRandom.hex) }
+
+  it "works" do
+    get "/brightcove/video/#{video.video_id}"
+    expect(response.status).to eq(200)
+  end
+
+  it "raises 404 for missing video" do
+    get "/brightcove/video/123"
+    expect(response.status).to eq(404)
+  end
+
+  it "raises 404 for tombstoned video" do
+    video.update(tombstoned_at: Time.zone.now)
+    get "/brightcove/video/#{video.video_id}"
+    expect(response.status).to eq(404)
+  end
+
+end


### PR DESCRIPTION
For safety, Videos are marked as 'tombstoned' for 7 days. During this time, they cannot be viewed in Discourse, but are kept on the Brightcove server.