### PR TITLE
FIX: do not use string for action

### DIFF
--- a/assets/javascripts/discourse/components/modal/brightcove-upload.hbs
+++ b/assets/javascripts/discourse/components/modal/brightcove-upload.hbs
@@ -31,7 +31,7 @@
     {{uploadProgress}}
   {{else}}
     <DButton
-      @action="upload"
+      @action={{this.upload}}
       @icon="upload"
       @label="upload"
       @disabled={{uploadDisabled}}

--- a/assets/javascripts/discourse/components/modal/brightcove-upload.js
+++ b/assets/javascripts/discourse/components/modal/brightcove-upload.js
@@ -1,4 +1,5 @@
 import Component from "@ember/component";
+import { action } from "@ember/object";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import discourseComputed from "discourse-common/utils/decorators";
@@ -152,17 +153,17 @@ export default Component.extend({
     return !(file && videoName);
   },
 
-  actions: {
-    fileChanged(event) {
-      // eslint-disable-next-line no-console
-      console.log("File Changed", event.target.files[0]);
-      const file = event.target.files[0];
-      this.set("file", file);
-    },
+  @action
+  fileChanged(event) {
+    // eslint-disable-next-line no-console
+    console.log("File Changed", event.target.files[0]);
+    const file = event.target.files[0];
+    this.set("file", file);
+  },
 
-    upload() {
-      this.createVideoObject();
-    },
+  @action
+  upload() {
+    this.createVideoObject();
   },
 });
 


### PR DESCRIPTION
This was causing a test failure.

```
index.js:118 Uncaught (in promise) Error: Assertion Failed: You attempted to update `_value` on `TrackedStorageImpl`, but it had already been used previously in the same computation.  Attempting to update a value after using it in a computation can cause logical errors, infinite revalidation bugs, and performance issues, and is not supported.

`_value` was first used:

- While rendering:
  -top-level
    application
      discourse-root
        modal-container
          Class
            d-modal
              (unknown template-only component)
                (unknown template-only component)
                  d-button
```

This commit also moves away from the old: `actions: {}`pattern.