### PR TITLE
Update icons: exclamation-triangle to triangle-exclamation and question-circle to circle-question

### DIFF
--- a/assets/javascripts/discourse/initializers/discourse-brightcove.js
+++ b/assets/javascripts/discourse/initializers/discourse-brightcove.js
@@ -25,11 +25,11 @@ function initializeBrightcove(api) {
       string: I18n.t("brightcove.state.pending"),
     },
     errored: {
-      iconHtml: renderIcon("string", "exclamation-triangle"),
+      iconHtml: renderIcon("string", "triangle-exclamation"),
       string: I18n.t("brightcove.state.errored"),
     },
     unknown: {
-      iconHtml: renderIcon("string", "question-circle"),
+      iconHtml: renderIcon("string", "circle-question"),
       string: I18n.t("brightcove.state.unknown"),
     },
   };


### PR DESCRIPTION
Due to : https://meta.discourse.org/t/banner-on-home-page-action-required/348875?u=yigit

* exclamation-triangle -> triangle-exclamation
* question-circle -> circle-question

Above icon names are updated according to below [console depreciation notices:](https://www.fmcdealercommunity.com)
![Screenshot 2025-01-27 at 15 26 47](https://github.com/user-attachments/assets/0f25826e-db7d-458b-9c95-eafd301c7ecd)


