### PR TITLE
SECURITY: Unscoped Brightcove video lookups let uploaders operate on other users' videos

### DIFF
--- a/app/controllers/brightcove/upload_controller.rb
+++ b/app/controllers/brightcove/upload_controller.rb
@@ -58,8 +58,8 @@ module Brightcove
       to_sign = params.require(:to_sign)
       datetime = params.require(:datetime)
 
-      video = Brightcove::Video.find_by_video_id(video_id)
-      raise Discourse::NotFound if video.nil? || video.secret_access_key.nil?
+      video = find_current_user_video(video_id)
+      raise Discourse::NotFound if video.secret_access_key.nil?
 
       secret = video.secret_access_key
       aws_region = "us-east-1"
@@ -77,8 +77,10 @@ module Brightcove
     def ingest
       video_id = params.require(:video_id)
 
-      video = Brightcove::Video.find_by_video_id(video_id)
-      raise Discourse::NotFound if video.nil? || video.api_request_url.nil?
+      video = find_current_user_video(video_id)
+      if video.api_request_url.nil? || video.state != Brightcove::Video::PENDING
+        raise Discourse::NotFound
+      end
 
       video.callback_key = SecureRandom.hex
       video.save!
@@ -118,6 +120,13 @@ module Brightcove
     end
 
     private
+
+    def find_current_user_video(video_id)
+      video = Brightcove::Video.find_by(video_id: video_id, user: current_user)
+      raise Discourse::NotFound if video.nil?
+
+      video
+    end
 
     def hmac(key, value)
       OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), key, value)

--- a/spec/requests/upload_controller_spec.rb
+++ b/spec/requests/upload_controller_spec.rb
@@ -49,7 +49,8 @@ RSpec.describe Brightcove::UploadController do
     SiteSetting.brightcove_client_secret = "abc"
   end
 
-  let(:user) { Fabricate(:user) }
+  fab!(:user)
+  fab!(:other_user, :user)
 
   it "doesn't allow anon" do
     post "/brightcove/create.json", params: { name: "Test Name", filename: "filename.mp4" }
@@ -90,7 +91,12 @@ RSpec.describe Brightcove::UploadController do
     end
 
     it "allows signing" do
-      v = Brightcove::Video.create!(video_id: 12, secret_access_key: "abcd", state: "pending")
+      Brightcove::Video.create!(
+        video_id: 12,
+        secret_access_key: "abcd",
+        state: "pending",
+        user: user,
+      )
       get "/brightcove/sign/12.json",
           params: {
             to_sign: "some string",
@@ -103,17 +109,63 @@ RSpec.describe Brightcove::UploadController do
     end
 
     it "allows ingest" do
-      v =
-        Brightcove::Video.create!(
-          video_id: "12",
-          secret_access_key: "abcd",
-          state: "pending",
-          api_request_url: "https://hello.world/video.mp4",
-        )
+      Brightcove::Video.create!(
+        video_id: "12",
+        secret_access_key: "abcd",
+        state: "pending",
+        api_request_url: "https://hello.world/video.mp4",
+        user: user,
+      )
       post "/brightcove/ingest/12.json"
       expect(response.status).to eq(200)
       json = ::JSON.parse(response.body)
       expect(json["success"]).to eq("OK")
+    end
+
+    it "prevents uploaders from using videos they do not own or ingesting completed videos" do
+      Brightcove::Video.create!(
+        video_id: "12",
+        secret_access_key: "other-secret",
+        state: "pending",
+        api_request_url: "https://hello.world/other.mp4",
+        user: other_user,
+      )
+      Brightcove::Video.create!(
+        video_id: "13",
+        secret_access_key: "own-secret",
+        state: "ready",
+        api_request_url: "https://hello.world/ready.mp4",
+        user: user,
+      )
+      ready_ingest_request_stub =
+        stub_request(
+          :post,
+          "https://ingest.api.brightcove.com/v1/accounts/987654321/videos/13/ingest-requests",
+        ).to_return(status: 204)
+
+      get "/brightcove/sign/12.json",
+          params: {
+            to_sign: "some string",
+            datetime: "20180512T12:00Z",
+          }
+      sign_response = { status: response.status, body: response.body }
+
+      post "/brightcove/ingest/12.json"
+      other_ingest_response = { status: response.status, body: response.body }
+
+      post "/brightcove/ingest/13.json"
+      ready_ingest_response = { status: response.status, body: response.body }
+
+      aggregate_failures do
+        expect(sign_response[:status]).to eq(404)
+        expect(sign_response[:body]).to include("errors")
+        expect(other_ingest_response[:status]).to eq(404)
+        expect(other_ingest_response[:body]).to include("errors")
+        expect(ready_ingest_response[:status]).to eq(404)
+        expect(ready_ingest_response[:body]).to include("errors")
+        expect(ingest_request_stub).not_to have_been_requested
+        expect(ready_ingest_request_stub).not_to have_been_requested
+      end
     end
   end
 


### PR DESCRIPTION
## Summary

A user that is allowed to upload and knows or enumerates another user’s Brightcove `video_id` can make the server use that video’s stored secret_access_key to sign supplied AWS strings. Allowing the user to drive that video through a new ingest lifecycle without owning it.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1214

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>